### PR TITLE
Implemented region components

### DIFF
--- a/wagtail_localize/admin/regions/components.py
+++ b/wagtail_localize/admin/regions/components.py
@@ -1,0 +1,28 @@
+import functools
+
+from wagtail.admin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
+
+
+REGION_COMPONENTS = []
+
+
+def get_region_components():
+    return REGION_COMPONENTS
+
+
+def register_region_component(model):
+    if model not in REGION_COMPONENTS:
+        REGION_COMPONENTS.append(model)
+        REGION_COMPONENTS.sort(key=lambda x: x._meta.verbose_name)
+
+    return model
+
+
+@functools.lru_cache()
+def get_region_component_edit_handler(model):
+    if hasattr(model, 'edit_handler'):
+        # use the edit handler specified on the class
+        return model.edit_handler
+    else:
+        panels = extract_panel_definitions_from_model_class(model, exclude=['region'])
+        return ObjectList(panels)

--- a/wagtail_localize/admin/regions/templates/wagtail_localize_regions_admin/create.html
+++ b/wagtail_localize/admin/regions/templates/wagtail_localize_regions_admin/create.html
@@ -10,6 +10,12 @@
 
         {% block hidden_fields %}
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+
+            {% for component_model, component_instance, component_form in components %}
+                {% for field in component_form.hidden_fields %}
+                    {{ field }}
+                {% endfor %}
+            {% endfor %}
         {% endblock %}
 
         <div class="nice-padding">
@@ -17,6 +23,12 @@
                 {% block visible_fields %}
                     {% for field in form.visible_fields %}
                         {% include "wagtailadmin/shared/field_as_li.html" %}
+                    {% endfor %}
+
+                    {% for component_model, component_instance, component_form in components %}
+                        {% for field in component_form.visible_fields %}
+                            {% include "wagtailadmin/shared/field_as_li.html" %}
+                        {% endfor %}
                     {% endfor %}
                 {% endblock %}
                 <li><input type="submit" value="{% trans 'Save' %}" class="button" /></li>

--- a/wagtail_localize/admin/regions/templates/wagtail_localize_regions_admin/edit.html
+++ b/wagtail_localize/admin/regions/templates/wagtail_localize_regions_admin/edit.html
@@ -12,12 +12,24 @@
 
             {% block hidden_fields %}
                 {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+
+                {% for component_model, component_instance, component_form in components %}
+                    {% for field in component_form.hidden_fields %}
+                        {{ field }}
+                    {% endfor %}
+                {% endfor %}
             {% endblock %}
 
             <ul class="fields">
                 {% block visible_fields %}
                     {% for field in form.visible_fields %}
                         {% include "wagtailadmin/shared/field_as_li.html" %}
+                    {% endfor %}
+
+                    {% for component_model, component_instance, component_form in components %}
+                        {% for field in component_form.visible_fields %}
+                            {% include "wagtailadmin/shared/field_as_li.html" %}
+                        {% endfor %}
                     {% endfor %}
                 {% endblock %}
 

--- a/wagtail_localize/admin/regions/views.py
+++ b/wagtail_localize/admin/regions/views.py
@@ -6,7 +6,44 @@ from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.core.permission_policies import ModelPermissionPolicy
 
 from wagtail_localize.models import Region
+from .components import get_region_components, get_region_component_edit_handler
 from .forms import RegionForm
+
+
+class RegionComponentManager:
+    def __init__(self, components):
+        self.components = components
+
+    @classmethod
+    def from_request(cls, request, instance=None):
+        components = []
+
+        for component_model in get_region_components():
+            component_instance = component_model.objects.filter(region=instance).first()
+            edit_handler = get_region_component_edit_handler(component_model).bind_to(model=component_model, instance=component_instance, request=request)
+            form_class = edit_handler.get_form_class()
+            prefix = f'component_{component_model._meta.app_label}_{component_model.__name__}'
+
+            if request.method == 'POST':
+                form = form_class(request.POST, request.FILES, instance=component_instance, prefix=prefix)
+            else:
+                form = form_class(instance=component_instance, prefix=prefix)
+
+            components.append((component_model, component_instance, form))
+
+        return cls(components)
+
+    def is_valid(self):
+        return all(component_form.is_valid() for component_model, component_instance, component_form in self.components)
+
+    def save(self, region):
+        for component_model, component_instance, component_form in self.components:
+            component_instance = component_form.save(commit=False)
+            component_instance.region = region
+            component_instance.save()
+
+    def __iter__(self):
+        return iter(self.components)
 
 
 class IndexView(generic.IndexView):
@@ -21,6 +58,29 @@ class CreateView(generic.CreateView):
     success_message = ugettext_lazy("Region '{0}' created.")
     template_name = 'wagtail_localize_regions_admin/create.html'
 
+    def get_components(self):
+        return RegionComponentManager.from_request(self.request)
+
+    def post(self, request, *args, **kwargs):
+        form = self.get_form()
+        self.components = RegionComponentManager.from_request(self.request)
+
+        if form.is_valid() and self.get_components().is_valid():
+            return self.form_valid(form)
+        else:
+            return self.form_invalid(form)
+
+    @transaction.atomic
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        self.get_components().save(self.object)
+        return response
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        context['components'] = self.get_components()
+        return context
+
 
 class EditView(generic.EditView):
     success_message = ugettext_lazy("Region '{0}' updated.")
@@ -28,6 +88,29 @@ class EditView(generic.EditView):
     delete_item_label = ugettext_lazy("Delete region")
     context_object_name = 'region'
     template_name = 'wagtail_localize_regions_admin/edit.html'
+
+    def get_components(self):
+        return RegionComponentManager.from_request(self.request, instance=self.object)
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        form = self.get_form()
+
+        if form.is_valid() and self.get_components().is_valid():
+            return self.form_valid(form)
+        else:
+            return self.form_invalid(form)
+
+    @transaction.atomic
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        self.get_components().save(self.object)
+        return response
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        context['components'] = self.get_components()
+        return context
 
 
 class DeleteView(generic.DeleteView):


### PR DESCRIPTION
Fixes #3

This allows you to add additional fields to a region.

For example, the following would add a "flag image" field:

```python
from wagtail_localize.admin.regions.components import register_region_component

@register_region_component
class RegionFlag(models.Model):
    region = models.OneToOneField('wagtail_localize.Region', on_delete=models.CASCADE, related_name='flag')
    flag_image = models.ForeignKey('wagtailimages.Image', on_delete=models.CASCADE, related_name='+')
```